### PR TITLE
Fixed bug in afflux initial assumption.

### DIFF
--- a/samples/weirs/sample_sharpcrested/source/app.d
+++ b/samples/weirs/sample_sharpcrested/source/app.d
@@ -4,4 +4,15 @@ import hydroflow;
 void main()
 {
 	SharpCrestedWeir scw = new SharpCrestedWeir();
+
+	scw.discharge = 100;
+	scw.usApronElev = 50;
+	scw.dsApronElev = 49.4;
+	scw.crestLength = 30;
+	scw.crestElev = 52;
+	scw.tailwaterElev = 52.5;
+
+	scw.analysis();
+
+	writeln("Afflux elevation: ", scw.affluxElevation);
 }

--- a/source/libs/weirs/sharpcrested.d
+++ b/source/libs/weirs/sharpcrested.d
@@ -9,6 +9,7 @@ import libs.utils.constants;
 import libs.utils.hydraulics;
 
 import std.math: abs, pow, sqrt;
+import std.stdio;
 
 /**
     SharpCrestedWeir class.
@@ -51,8 +52,14 @@ class SharpCrestedWeir : Weir
         TRIAL_INCREMENT = 0.0001;
 
         dischargeIntensity = discharge / crestLength;
-        affluxElevation += TRIAL_INCREMENT;
+
+        // Afflux elevation initial assumption
+        affluxElevation = crestElev > tailwaterElev ? crestElev : tailwaterElev;
+
+        // Accuracy closure
         const allowedDiff = discharge * ERROR;
+
+        calculatedDischargeIntensity = 0;
 
         // Calculation for the afflux elevation
         while (abs(dischargeIntensity - calculatedDischargeIntensity) > allowedDiff) 
@@ -60,7 +67,7 @@ class SharpCrestedWeir : Weir
             affluxElevation += TRIAL_INCREMENT;
             dA = affluxElevation - usApronElev;
             vA = dischargeIntensity / dA;
-            hA = pow(vA, 2) / (2 * GRAVITY);
+            hA = velocityHead(vA);
             eE = affluxElevation + hA;
             ho = eE - crestElev;
             co = 3.33 * (1 + 0.259 * pow(ho, 2) / pow(dA, 2));
@@ -77,7 +84,6 @@ class SharpCrestedWeir : Weir
             }
             cs = co * correction;
             calculatedDischargeIntensity = cs / 1.811 * pow(ho, (3.0 / 2.0));
-
             // My root-finding acceleration
             if (calculatedDischargeIntensity < dischargeIntensity)
             {

--- a/source/libs/weirs/weir.d
+++ b/source/libs/weirs/weir.d
@@ -11,7 +11,7 @@ class Weir
     ///////////////////////////////////////
     //  Constants                        //
     ///////////////////////////////////////
-    protected const double ERROR = 0.002;             // Allowed accuracy in iteration
+    protected const double ERROR = 0.0001;             // Allowed accuracy in iteration
     
     ///////////////////////////////////////
     //  Properties                       //
@@ -34,5 +34,5 @@ class Weir
 
     double calculatedDischargeIntensity;
 
-    protected double affluxElevation;
+    double affluxElevation;
 }


### PR DESCRIPTION
Previous initial assumption of afflux is not set, so nAn.
Set the initial value to either crest elevation or tail water elevation, whichever is higher as the afflux cannot be less that that.